### PR TITLE
ci(deploy): Add Playwright browser caching to optimize CI/CD performance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,8 +32,24 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npm list @playwright/test --depth=0 --json | jq -r '.dependencies["@playwright/test"].version')" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Validate HTML
         run: |


### PR DESCRIPTION
- Add step to extract Playwright version from package dependencies
- Implement GitHub Actions cache for Playwright browser binaries
- Cache stored at ~/.cache/ms-playwright with OS and version-specific keys
- Skip browser installation when cache hit is detected
- Install system dependencies separately when using cached browsers
- Reduces CI/CD pipeline execution time by avoiding redundant browser downloads