### PR TITLE
fix: skip deploy workflow on release commits to avoid duplicate runs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,11 +32,19 @@ jobs:
         id: check-release
         run: |
           # Check if this is a merge commit from a PR with a release label
+          # OR if this is a release commit created by the release workflow
           # If so, skip tests since release workflow will run them
           if [ "${{ github.event_name }}" = "push" ]; then
             # Get the commit message
             COMMIT_MSG=$(git log -1 --pretty=%B)
             echo "Commit message: $COMMIT_MSG"
+            
+            # Check if this is a release commit (created by release-it)
+            if echo "$COMMIT_MSG" | grep -qE "^chore: release v[0-9]+\.[0-9]+\.[0-9]+"; then
+              echo "Release commit detected - skipping duplicate deploy"
+              echo "skip=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
             
             # Check if this is a merge commit from a PR
             if echo "$COMMIT_MSG" | grep -qE "^.*\(#[0-9]+\)$"; then


### PR DESCRIPTION
Prevents the deploy workflow from running twice when a release is created:

**Problem:**
When a PR with a release label is merged:
1. Merge commit triggers deploy workflow
2. Release workflow creates a new commit and pushes it
3. Release commit triggers deploy workflow again (duplicate!)

**Solution:**
Added check to detect release commits (pattern: 'chore: release vX.X.X') and skip the deploy workflow for those commits. The release workflow already triggers the deploy workflow explicitly via workflow_dispatch, so we don't need the automatic trigger.

**Result:**
- Saves ~3 minutes of CI time per release
- Avoids running expensive Playwright tests twice
- Cleaner workflow runs