### PR TITLE
fix: update zen points display when returning from free play mode

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1549,6 +1549,9 @@ export function returnToModeSelection() {
         // Show version footer when returning to landing page
         showVersionFooter();
 
+        // Update display to show current zen points balance from ZenPointsManager
+        updateDisplay();
+
         console.log('Returned to mode selection');
 
     } catch (error) {

--- a/tests/playwright/game-modes.spec.js
+++ b/tests/playwright/game-modes.spec.js
@@ -184,6 +184,31 @@ test.describe('Free Play Mode', () => {
 
         await expect(versionFooter).toBeVisible();
     });
+
+    test('should display zen points correctly when returning from free play mode', async ({ page }) => {
+        // Get initial zen points from landing page
+        const zenPointsElement = page.locator('#zenPoints');
+        const initialZenPoints = await zenPointsElement.textContent();
+
+        // Start Free Play Mode
+        await page.getByRole('button', { name: /Start Free Play/i }).click();
+        await expect(page.locator('#gameArea')).toBeVisible();
+
+        // Zen points should still be visible in game area
+        await expect(zenPointsElement).toBeVisible();
+
+        // Return to mode selection
+        page.on('dialog', dialog => dialog.accept());
+        await page.locator('#taskCloseBtn').click();
+
+        // Verify we're back at mode selection
+        await expect(page.locator('#gameModeSelection')).toBeVisible();
+
+        // Verify zen points are displayed and match initial value
+        await expect(zenPointsElement).toBeVisible();
+        const finalZenPoints = await zenPointsElement.textContent();
+        expect(finalZenPoints).toBe(initialZenPoints);
+    });
 });
 
 test.describe('Screen Navigation - Bug Fix', () => {


### PR DESCRIPTION
When exiting Free Play Mode and returning to the main landing screen, the zen points total wasn't being updated in the UI header. Added updateDisplay() call in returnToModeSelection() to refresh the UI with current zen points balance. Includes test to verify zen points display is correct on all viewports.