### PR TITLE
fix: shop navigation returns to correct mode

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -477,10 +477,11 @@ export function closeTask() {
 // Close shop wrapper
 export function closeShopWrapper() {
     closeShop();
-    if (gameState.freePlayMode) {
-        showFreePlayOverview();
-    } else if (isCampaignMode()) {
+    // Check Campaign Mode first (more specific), then Free Play
+    if (isCampaignMode()) {
         showElement('campaignOverview');
+    } else if (gameState.freePlayMode) {
+        showFreePlayOverview();
     } else {
         showElement('gameModeSelection');
         // Show version footer when returning to landing page
@@ -491,10 +492,11 @@ export function closeShopWrapper() {
 // Close Mind Palace wrapper - handles navigation based on current mode
 export function closeMindPalaceWrapper() {
     hideMindPalace();
-    if (gameState.freePlayMode) {
-        showFreePlayOverview();
-    } else if (isCampaignMode()) {
+    // Check Campaign Mode first (more specific), then Free Play
+    if (isCampaignMode()) {
         showElement('campaignOverview');
+    } else if (gameState.freePlayMode) {
+        showFreePlayOverview();
     } else {
         showElement('gameModeSelection');
         // Show version footer when returning to landing page
@@ -2139,21 +2141,50 @@ export function purchaseJoker() {
 
 export function continueCampaign() {
     closeShop();
-    returnToCampaign();
-    // Update campaign UI to reflect any purchases
-    updateCampaignUI();
+    // Check which mode we're in and return to appropriate view
+    // Check Campaign Mode first (more specific), then Free Play
+    if (isCampaignMode()) {
+        returnToCampaign();
+        // Update campaign UI to reflect any purchases
+        updateCampaignUI();
+    } else if (gameState.freePlayMode) {
+        showFreePlayOverview();
+    } else {
+        // Fallback to campaign for other modes (Jump Into Task, etc.)
+        returnToCampaign();
+        updateCampaignUI();
+    }
 }
 
 export function skipShop() {
     closeShop();
-    returnToCampaign();
+    // Check which mode we're in and return to appropriate view
+    // Check Campaign Mode first (more specific), then Free Play
+    if (isCampaignMode()) {
+        returnToCampaign();
+    } else if (gameState.freePlayMode) {
+        showFreePlayOverview();
+    } else {
+        // Fallback to campaign for other modes (Jump Into Task, etc.)
+        returnToCampaign();
+    }
 }
 
 export function closeShopToCampaign() {
     closeShop();
-    returnToCampaign();
-    // Update campaign UI to reflect any purchases
-    updateCampaignUI();
+    // Check which mode we're in and return to appropriate view
+    // Check Campaign Mode first (more specific), then Free Play
+    if (isCampaignMode()) {
+        returnToCampaign();
+        // Update campaign UI to reflect any purchases
+        updateCampaignUI();
+    } else if (gameState.freePlayMode) {
+        showFreePlayOverview();
+    } else {
+        // Fallback to campaign for other modes (Jump Into Task, etc.)
+        returnToCampaign();
+        updateCampaignUI();
+    }
 }
 
 export function visitMindPalace() {

--- a/assets/js/shop-system.js
+++ b/assets/js/shop-system.js
@@ -2,6 +2,7 @@
 // Upgrade purchasing logic and deck modifications
 
 import { campaignState, updateCampaignState, unlockPremiumActivity } from './game-state.js';
+import { isCampaignMode } from './campaign-manager.js';
 import { hideElement, showElement } from './ui-manager.js';
 import { ZenPointsManager, ZEN_TRANSACTION_TYPES } from './zen-points-manager.js';
 
@@ -406,6 +407,7 @@ function updatePremiumActivityUI(activityId, zenPoints) {
 export function openShop(zenPoints) {
     try {
         updateShopUI(zenPoints);
+        updateShopButtonText(); // Update button text based on current mode
         showElement('upgradeShop');
 
         // Focus on shop for accessibility
@@ -418,6 +420,31 @@ export function openShop(zenPoints) {
 
     } catch (error) {
         console.error('Error opening shop:', error);
+    }
+}
+
+// Update shop button text based on current game mode
+function updateShopButtonText() {
+    try {
+        // Get the "Continue Campaign" button
+        const continueCampaignBtn = document.querySelector('.shop-actions .primary-btn');
+
+        if (continueCampaignBtn) {
+            // Check which overview screen is currently visible to determine mode
+            const freePlayOverviewVisible = !document.getElementById('freePlayOverview')?.classList.contains('hidden');
+            const campaignOverviewVisible = !document.getElementById('campaignOverview')?.classList.contains('hidden');
+
+            if (freePlayOverviewVisible) {
+                continueCampaignBtn.textContent = 'Continue Free Play';
+            } else if (campaignOverviewVisible || isCampaignMode()) {
+                continueCampaignBtn.textContent = 'Continue Campaign';
+            } else {
+                // Default to Campaign if we can't determine
+                continueCampaignBtn.textContent = 'Continue Campaign';
+            }
+        }
+    } catch (error) {
+        console.error('Error updating shop button text:', error);
     }
 }
 

--- a/tests/playwright/shop-navigation.spec.js
+++ b/tests/playwright/shop-navigation.spec.js
@@ -1,0 +1,281 @@
+// SoberLife III - Shop Navigation Tests
+// Tests for shop exit navigation issues across different game modes
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Shop Navigation Issues', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+    });
+
+    test('Shop X button should return to Campaign Mode when opened from Campaign', async ({ page }) => {
+        // Start Campaign Mode
+        await page.locator('button:has-text("Start Campaign")').click();
+        await expect(page.locator('#campaignOverview')).toBeVisible();
+
+        // Open shop from campaign overview using specific selector
+        await page.locator('#campaignOverview button:has-text("Visit Shop")').click();
+        await expect(page.locator('#upgradeShop')).toBeVisible();
+
+        // Click X button to close shop
+        await page.locator('#shopCloseBtn').click();
+
+        // BUG TEST: Should return to Campaign Mode, NOT Free Play Mode
+        await expect(page.locator('#campaignOverview')).toBeVisible();
+        await expect(page.locator('#freePlayOverview')).not.toBeVisible();
+        await expect(page.locator('#gameModeSelection')).not.toBeVisible();
+    });
+
+    test('Shop X button should return to Free Play overview when opened from Free Play', async ({ page }) => {
+        // Start Free Play Mode (goes directly to gameplay)
+        await page.locator('button:has-text("Start Free Play")').click();
+        await expect(page.locator('#gameArea')).toBeVisible();
+
+        // Exit the game to show Free Play overview (handle confirmation dialog)
+        page.once('dialog', dialog => dialog.accept());
+        await page.locator('#taskCloseBtn').click();
+        await expect(page.locator('#freePlayOverview')).toBeVisible();
+
+        // Open shop from Free Play overview using specific selector
+        await page.locator('#freePlayOverview button:has-text("Visit Shop")').click();
+        await expect(page.locator('#upgradeShop')).toBeVisible();
+
+        // Click X button to close shop
+        await page.locator('#shopCloseBtn').click();
+
+        // BUG TEST: Should return to Free Play overview, NOT Campaign Mode
+        await expect(page.locator('#freePlayOverview')).toBeVisible();
+        await expect(page.locator('#campaignOverview')).not.toBeVisible();
+        await expect(page.locator('#gameModeSelection')).not.toBeVisible();
+    });
+
+    test('Shop "Continue Campaign" button should return to Campaign Mode when opened from Campaign', async ({ page }) => {
+        // Start Campaign Mode
+        await page.locator('button:has-text("Start Campaign")').click();
+        await expect(page.locator('#campaignOverview')).toBeVisible();
+
+        // Open shop from campaign overview using specific selector
+        await page.locator('#campaignOverview button:has-text("Visit Shop")').click();
+        await expect(page.locator('#upgradeShop')).toBeVisible();
+
+        // Click "Continue Campaign" button (use visible one in shop)
+        await page.locator('#upgradeShop button:has-text("Continue Campaign")').click();
+
+        // Should return to Campaign Mode
+        await expect(page.locator('#campaignOverview')).toBeVisible();
+        await expect(page.locator('#freePlayOverview')).not.toBeVisible();
+        await expect(page.locator('#gameModeSelection')).not.toBeVisible();
+    });
+
+    test('Shop "Continue Free Play" button should return to Free Play overview when opened from Free Play', async ({ page }) => {
+        // Start Free Play Mode (goes directly to gameplay)
+        await page.locator('button:has-text("Start Free Play")').click();
+        await expect(page.locator('#gameArea')).toBeVisible();
+
+        // Exit the game to show Free Play overview (handle confirmation dialog)
+        page.once('dialog', dialog => dialog.accept());
+        await page.locator('#taskCloseBtn').click();
+        await expect(page.locator('#freePlayOverview')).toBeVisible();
+
+        // Open shop from Free Play overview using specific selector
+        await page.locator('#freePlayOverview button:has-text("Visit Shop")').click();
+        await expect(page.locator('#upgradeShop')).toBeVisible();
+
+        // Verify button text changed to "Continue Free Play"
+        await expect(page.locator('button:has-text("Continue Free Play")')).toBeVisible();
+
+        // Click "Continue Free Play" button
+        await page.locator('button:has-text("Continue Free Play")').click();
+
+        // BUG TEST: Should return to Free Play overview, NOT Campaign Mode
+        await expect(page.locator('#freePlayOverview')).toBeVisible();
+        await expect(page.locator('#campaignOverview')).not.toBeVisible();
+        await expect(page.locator('#gameModeSelection')).not.toBeVisible();
+    });
+
+    test('Shop "Close Shop" button should return to Campaign Mode when opened from Campaign', async ({ page }) => {
+        // Start Campaign Mode
+        await page.locator('button:has-text("Start Campaign")').click();
+        await expect(page.locator('#campaignOverview')).toBeVisible();
+
+        // Open shop from campaign overview using specific selector
+        await page.locator('#campaignOverview button:has-text("Visit Shop")').click();
+        await expect(page.locator('#upgradeShop')).toBeVisible();
+
+        // Click "Close Shop" button
+        await page.locator('button:has-text("Close Shop")').click();
+
+        // Should return to Campaign Mode
+        await expect(page.locator('#campaignOverview')).toBeVisible();
+        await expect(page.locator('#freePlayOverview')).not.toBeVisible();
+        await expect(page.locator('#gameModeSelection')).not.toBeVisible();
+    });
+
+    test('Shop "Close Shop" button should return to Free Play overview when opened from Free Play', async ({ page }) => {
+        // Start Free Play Mode (goes directly to gameplay)
+        await page.locator('button:has-text("Start Free Play")').click();
+        await expect(page.locator('#gameArea')).toBeVisible();
+
+        // Exit the game to show Free Play overview (handle confirmation dialog)
+        page.once('dialog', dialog => dialog.accept());
+        await page.locator('#taskCloseBtn').click();
+        await expect(page.locator('#freePlayOverview')).toBeVisible();
+
+        // Open shop from Free Play overview using specific selector
+        await page.locator('#freePlayOverview button:has-text("Visit Shop")').click();
+        await expect(page.locator('#upgradeShop')).toBeVisible();
+
+        // Click "Close Shop" button
+        await page.locator('button:has-text("Close Shop")').click();
+
+        // BUG TEST: Should return to Free Play overview, NOT Campaign Mode
+        await expect(page.locator('#freePlayOverview')).toBeVisible();
+        await expect(page.locator('#campaignOverview')).not.toBeVisible();
+        await expect(page.locator('#gameModeSelection')).not.toBeVisible();
+    });
+
+    test('Free Play shop should allow purchases without Campaign Mode restriction', async ({ page }) => {
+        // Start Free Play Mode (goes directly to gameplay)
+        await page.locator('button:has-text("Start Free Play")').click();
+        await expect(page.locator('#gameArea')).toBeVisible();
+
+        // Exit the game to show Free Play overview (handle confirmation dialog)
+        page.once('dialog', dialog => dialog.accept());
+        await page.locator('#taskCloseBtn').click();
+        await expect(page.locator('#freePlayOverview')).toBeVisible();
+
+        // Open shop from Free Play overview using specific selector
+        await page.locator('#freePlayOverview button:has-text("Visit Shop")').click();
+        await expect(page.locator('#upgradeShop')).toBeVisible();
+
+        // Check if joker upgrade button is enabled (assuming player has enough zen points)
+        // First, let's check the current zen points
+        const zenPointsText = await page.locator('#shopZenPoints').textContent();
+        console.log('Current zen points:', zenPointsText);
+
+        // The joker upgrade button should NOT be disabled due to "not in campaign mode"
+        const jokerBtn = page.locator('#jokerUpgradeBtn');
+        const isDisabled = await jokerBtn.isDisabled();
+        const buttonText = await jokerBtn.textContent();
+
+        // BUG TEST: Button should not say "Campaign Mode Only" or similar
+        expect(buttonText).not.toContain('Campaign');
+        expect(buttonText).not.toContain('Mode Only');
+
+        // If player has enough zen points, button should be enabled
+        // If disabled, it should only be due to insufficient zen or max jokers reached
+        if (isDisabled) {
+            expect(buttonText).toMatch(/Insufficient Zen|Max Jokers Reached|Cannot Purchase/);
+        }
+    });
+
+    test('Shop should remember which mode opened it for proper navigation', async ({ page }) => {
+        // Test 1: Campaign Mode
+        await page.locator('button:has-text("Start Campaign")').click();
+        await expect(page.locator('#campaignOverview')).toBeVisible();
+        await page.locator('#campaignOverview button:has-text("Visit Shop")').click();
+        await expect(page.locator('#upgradeShop')).toBeVisible();
+        await page.locator('#shopCloseBtn').click();
+        await expect(page.locator('#campaignOverview')).toBeVisible();
+
+        // Return to mode selection
+        await page.locator('#campaignCloseBtn').click();
+        await expect(page.locator('#gameModeSelection')).toBeVisible();
+
+        // Test 2: Free Play Mode
+        await page.locator('button:has-text("Start Free Play")').click();
+        await expect(page.locator('#gameArea')).toBeVisible();
+
+        // Exit the game to show Free Play overview (handle confirmation dialog)
+        page.once('dialog', dialog => dialog.accept());
+        await page.locator('#taskCloseBtn').click();
+        await expect(page.locator('#freePlayOverview')).toBeVisible();
+
+        await page.locator('#freePlayOverview button:has-text("Visit Shop")').click();
+        await expect(page.locator('#upgradeShop')).toBeVisible();
+        await page.locator('#shopCloseBtn').click();
+
+        // BUG TEST: Should return to Free Play overview, not Campaign
+        await expect(page.locator('#freePlayOverview')).toBeVisible();
+        await expect(page.locator('#campaignOverview')).not.toBeVisible();
+    });
+
+    test('Shop "Continue Campaign" button should return to Campaign after Free Play session', async ({ page }) => {
+        // REGRESSION TEST: This test catches a bug where gameState.freePlayMode flag
+        // remains true after exiting Free Play, causing Campaign shop to incorrectly
+        // navigate to Free Play overview instead of Campaign overview.
+
+        // Step 1: Start Free Play to set the freePlayMode flag
+        await page.locator('button:has-text("Start Free Play")').click();
+        await expect(page.locator('#gameArea')).toBeVisible();
+
+        // Exit Free Play (this sets gameState.freePlayMode = true)
+        page.once('dialog', dialog => dialog.accept());
+        await page.locator('#taskCloseBtn').click();
+        await expect(page.locator('#freePlayOverview')).toBeVisible();
+
+        // Return to mode selection
+        await page.locator('#freePlayCloseBtn').click();
+        await expect(page.locator('#gameModeSelection')).toBeVisible();
+
+        // Step 2: Now start Campaign Mode (gameState.freePlayMode may still be true)
+        await page.locator('button:has-text("Start Campaign")').click();
+        await expect(page.locator('#campaignOverview')).toBeVisible();
+
+        // Open shop from Campaign
+        await page.locator('#campaignOverview button:has-text("Visit Shop")').click();
+        await expect(page.locator('#upgradeShop')).toBeVisible();
+
+        // Verify button text is correct
+        await expect(page.locator('#upgradeShop button:has-text("Continue Campaign")')).toBeVisible();
+
+        // Click "Continue Campaign" button
+        await page.locator('#upgradeShop button:has-text("Continue Campaign")').click();
+
+        // CRITICAL: Should return to Campaign overview, NOT Free Play overview
+        await expect(page.locator('#campaignOverview')).toBeVisible();
+        await expect(page.locator('#freePlayOverview')).not.toBeVisible();
+        await expect(page.locator('#gameModeSelection')).not.toBeVisible();
+
+        // Verify we're actually in Campaign Mode by checking the heading
+        await expect(page.locator('h2:has-text("Stress Management Campaign")')).toBeVisible();
+    });
+
+    test('Shop X button should return to Campaign after Free Play session', async ({ page }) => {
+        // REGRESSION TEST: This test catches the same bug as above, but specifically
+        // tests the X (close) button instead of the "Continue Campaign" button.
+
+        // Step 1: Start Free Play to set the freePlayMode flag
+        await page.locator('button:has-text("Start Free Play")').click();
+        await expect(page.locator('#gameArea')).toBeVisible();
+
+        // Exit Free Play (this sets gameState.freePlayMode = true)
+        page.once('dialog', dialog => dialog.accept());
+        await page.locator('#taskCloseBtn').click();
+        await expect(page.locator('#freePlayOverview')).toBeVisible();
+
+        // Return to mode selection
+        await page.locator('#freePlayCloseBtn').click();
+        await expect(page.locator('#gameModeSelection')).toBeVisible();
+
+        // Step 2: Now start Campaign Mode (gameState.freePlayMode may still be true)
+        await page.locator('button:has-text("Start Campaign")').click();
+        await expect(page.locator('#campaignOverview')).toBeVisible();
+
+        // Open shop from Campaign
+        await page.locator('#campaignOverview button:has-text("Visit Shop")').click();
+        await expect(page.locator('#upgradeShop')).toBeVisible();
+
+        // Click X button to close shop
+        await page.locator('#shopCloseBtn').click();
+
+        // CRITICAL: Should return to Campaign overview, NOT Free Play overview
+        await expect(page.locator('#campaignOverview')).toBeVisible();
+        await expect(page.locator('#freePlayOverview')).not.toBeVisible();
+        await expect(page.locator('#gameModeSelection')).not.toBeVisible();
+
+        // Verify we're actually in Campaign Mode by checking the heading
+        await expect(page.locator('h2:has-text("Stress Management Campaign")')).toBeVisible();
+    });
+});


### PR DESCRIPTION
## Summary

Fixes critical shop navigation bugs where players were returned to the wrong game mode screen after exiting the shop.

## Issues Fixed

1. **Shop X button** - Now returns to the originating mode (Campaign or Free Play)
2. **Continue/Close buttons** - Now check game mode before navigating
3. **Critical bug** - Fixed Free Play flag interfering with Campaign navigation after switching modes
4. **Button text** - Now dynamically updates (Continue Campaign vs Continue Free Play)

## Changes

- Updated 5 navigation functions in ssets/js/main.js with proper mode priority checking
- Added dynamic button text update in ssets/js/shop-system.js
- Created comprehensive test suite with 10 tests covering all scenarios

## Testing

- All 10 shop navigation tests passing across 3 viewports (30 total test runs)
- Verified proper navigation for Campaign, Free Play, and Jump Into Task modes
- No regressions introduced

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)