### PR TITLE
feat: skip tests for documentation PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
     inputs:
       skip_tests:
@@ -37,6 +38,13 @@ jobs:
       - name: Check if release workflow will run
         id: check-release
         run: |
+          # Check if this is a PR with documentation label
+          if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ contains(github.event.pull_request.labels.*.name, 'documentation') }}" = "true" ]; then
+            echo "Documentation label detected - skipping tests"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           # Check if this is a merge commit from a PR with a release label
           # OR if this is a release commit created by the release workflow
           # If so, skip tests since release workflow will run them


### PR DESCRIPTION
Fixes #52. Skips test and deploy jobs if the PR has the 'documentation' label.