### PR TITLE
feat: skip main branch workflow for documentation PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,6 +74,12 @@ jobs:
                 echo "skip=true" >> $GITHUB_OUTPUT
                 exit 0
               fi
+              
+              if echo "$LABELS" | grep -qE "^documentation$"; then
+                echo "Documentation label detected - skipping tests and deployment"
+                echo "skip=true" >> $GITHUB_OUTPUT
+                exit 0
+              fi
             fi
           fi
           echo "skip=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Extends the skip logic to the main branch. If a merged PR has the 'documentation' label, the main branch workflow will also be skipped.