### PR TITLE
fix: detect both regular and squash merge commits for documentation skip

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,12 +60,22 @@ jobs:
               exit 0
             fi
             
-            # Check if this is a merge commit from a PR
+            # Check if this is a merge commit from a PR (regular or squash merge)
+            # Regular merge: "Merge pull request #123 from..."
+            # Squash merge: "feat: description (#123)"
+            PR_NUM=""
             if echo "$COMMIT_MSG" | grep -qE "^Merge pull request #[0-9]+"; then
+              # Regular merge commit
               PR_NUM=$(echo "$COMMIT_MSG" | grep -oE "#[0-9]+" | head -1 | grep -oE "[0-9]+")
-              echo "Detected PR merge: #$PR_NUM"
-              
-              # Check if PR has a release label
+              echo "Detected regular PR merge: #$PR_NUM"
+            elif echo "$COMMIT_MSG" | grep -qE "\(#[0-9]+\)\s*$"; then
+              # Squash merge commit
+              PR_NUM=$(echo "$COMMIT_MSG" | grep -oE "\(#[0-9]+\)" | grep -oE "[0-9]+")
+              echo "Detected squash PR merge: #$PR_NUM"
+            fi
+            
+            if [ -n "$PR_NUM" ]; then
+              # Check if PR has a release or documentation label
               LABELS=$(gh pr view $PR_NUM --json labels --jq '.labels[].name' || echo "")
               echo "PR labels: $LABELS"
               
@@ -80,7 +90,6 @@ jobs:
                 echo "skip=true" >> $GITHUB_OUTPUT
                 exit 0
               fi
-            fi
           fi
           echo "skip=false" >> $GITHUB_OUTPUT
         env:

--- a/.kiro/steering/agent-workflows.md
+++ b/.kiro/steering/agent-workflows.md
@@ -17,7 +17,7 @@ This workflow allows the agent to take a GitHub issue number, analyze it, reprod
 5.  **Verify**: Runs the test to confirm the fix and ensures no regressions.
 6.  **Commit**: Commits the changes with a reference to the issue.
 7.  **PR**: Pushes the branch and creates a Pull Request using `gh pr create`.
-8.  **Merge**: Merges the PR using `gh pr merge` and updates the local main branch.
+8.  **Merge**: Merges the PR using `gh pr merge --merge --delete-branch` (use merge commits, not squash) and updates the local main branch.
 
 **Usage**:
 Ensure the `gh` CLI is authenticated and available.


### PR DESCRIPTION
This PR fixes the issue where squash merge commits were not being detected for the documentation label skip logic.

## Changes
- Updated deploy.yml to detect PR numbers from both regular merge commits (Merge pull request #123) and squash merge commits (feat: description (#123))
- Updated agent workflows documentation to recommend using merge commits over squash

Fixes #52