### PR TITLE
fix: add missing fi statement in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,6 +90,7 @@ jobs:
                 echo "skip=true" >> $GITHUB_OUTPUT
                 exit 0
               fi
+            fi
           fi
           echo "skip=false" >> $GITHUB_OUTPUT
         env:


### PR DESCRIPTION
Fixes bash syntax error caused by missing fi statement to close the push event conditional block.