### PR TITLE
fix: prevent hitting after bust when Compartmentalize offer shown

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1954,7 +1954,7 @@ function checkCompartmentalizeAvailable() {
 }
 
 // Offer compartmentalize option to player
-function offerCompartmentalize() {
+export function offerCompartmentalize() {
     // Show compartmentalize option UI
     const gameArea = document.getElementById('gameArea');
     if (gameArea) {
@@ -1971,6 +1971,12 @@ function offerCompartmentalize() {
             </div>
         `;
         gameArea.appendChild(compartmentalizeOffer);
+
+        // Disable game buttons while offer is active
+        const hitBtn = document.getElementById('hitBtn');
+        const standBtn = document.getElementById('standBtn');
+        if (hitBtn) hitBtn.disabled = true;
+        if (standBtn) standBtn.disabled = true;
     }
 }
 
@@ -1983,6 +1989,12 @@ export function useCompartmentalizeWrapper() {
         // Remove compartmentalize offer
         const offer = document.querySelector('.compartmentalize-offer');
         if (offer) offer.remove();
+
+        // Re-enable game buttons for split hand play
+        const hitBtn = document.getElementById('hitBtn');
+        const standBtn = document.getElementById('standBtn');
+        if (hitBtn) hitBtn.disabled = false;
+        if (standBtn) standBtn.disabled = false;
 
         // Show split hands UI
         showSplitHandsUI(result.splitHands);
@@ -2004,6 +2016,12 @@ export function declineCompartmentalize() {
     // Remove compartmentalize offer
     const offer = document.querySelector('.compartmentalize-offer');
     if (offer) offer.remove();
+
+    // Re-enable game buttons (endRound will handle final state)
+    const hitBtn = document.getElementById('hitBtn');
+    const standBtn = document.getElementById('standBtn');
+    if (hitBtn) hitBtn.disabled = false;
+    if (standBtn) standBtn.disabled = false;
 
     // Proceed with normal bust
     endRound('bust');

--- a/index.html
+++ b/index.html
@@ -692,6 +692,7 @@
         window.completeBothHandsWrapper = mainModule.completeBothHandsWrapper;
         window.useCompartmentalizeWrapper = mainModule.useCompartmentalizeWrapper;
         window.declineCompartmentalize = mainModule.declineCompartmentalize;
+        window.offerCompartmentalize = mainModule.offerCompartmentalize;
         window.purchasePremiumActivityWrapper = purchasePremiumActivityWrapper;
         window.closeSurvey = mainModule.closeSurvey;
         window.closeTask = mainModule.closeTask;

--- a/tests/playwright/issue-71.spec.js
+++ b/tests/playwright/issue-71.spec.js
@@ -1,0 +1,74 @@
+const { test, expect } = require('@playwright/test');
+
+test('Issue 71: Hit button should be disabled when Compartmentalize is offered', async ({ page }) => {
+    // 1. Setup local storage with unlocked Compartmentalize and Zen Points
+    await page.goto('/');
+
+    await page.evaluate(() => {
+        const campaignState = {
+            currentTask: 0,
+            completedTasks: [],
+            totalZenEarned: 1000,
+            zenPointBalance: 1000,
+            lastBalanceUpdate: Date.now(),
+            campaignMode: true,
+            previousStressLevel: 0,
+            deckComposition: { aces: 4, jokers: 0, totalCards: 52 },
+            shopUpgrades: { acesAdded: 0, jokersAdded: 0, totalSpent: 0 },
+            taskProgress: {},
+            unlockedActivities: {
+                mindfulBreathing: true,
+                compartmentalize: true // Unlock Compartmentalize
+            },
+            activityStats: {
+                totalActivitiesUsed: 0,
+                compartmentalizeUses: 0,
+                premiumActivityUses: 0
+            }
+        };
+        localStorage.setItem('soberlife-campaign', JSON.stringify(campaignState));
+    });
+
+    // 2. Reload to apply state
+    await page.reload();
+
+    // 3. Start Single Task Mode directly (skips campaign overview)
+    await page.evaluate(() => {
+        // Override flavor text to speed up test
+        window.showFlavorText = () => { };
+        // Don't override showInitialFlavorText, instead set the state so it's skipped
+        // window.showInitialFlavorText = () => {}; 
+
+        // Start task
+        window.startSingleTaskMode();
+
+        // Force initial flavor text shown state
+        window.gameState.initialFlavorTextShown = true;
+
+        // Enable buttons just in case
+        const hitBtn = document.getElementById('hitBtn');
+        if (hitBtn) hitBtn.disabled = false;
+    });
+
+    // 5. Complete survey mock
+    await page.waitForSelector('#surveySection');
+    // 6. Force Compartmentalize Offer directly
+    await page.evaluate(() => {
+        // Ensure game is "in progress" so buttons would be active otherwise
+        window.gameState.gameInProgress = true;
+        const hitBtn = document.getElementById('hitBtn');
+        if (hitBtn) hitBtn.disabled = false; // Start enabled
+
+        // Call the function that should disable them (but currently doesn't)
+        window.offerCompartmentalize();
+    });
+
+    // 7. Verify Hit button state
+    const hitBtn = await page.$('#hitBtn');
+    const isDisabled = await hitBtn.getAttribute('disabled');
+
+    // Before fix: Button should be enabled (isDisabled is null)
+    // We expect it to be disabled (not null) for the fix.
+    // So this assertion should FAIL if the bug is present.
+    expect(isDisabled).not.toBeNull();
+});


### PR DESCRIPTION
- Disable Hit and Stand buttons when offerCompartmentalize() is called
- Re-enable buttons when player accepts offer (for split hand play)
- Re-enable buttons when player declines offer (endRound handles final state)
- Add Playwright test to verify button state during offer

Fixes #71
